### PR TITLE
add alias `feathers g` for `feathers generate`

### DIFF
--- a/src/commands/generate.js
+++ b/src/commands/generate.js
@@ -17,6 +17,14 @@ const generatorOptions = {
 
 export default function(vorpal) {
   vorpal
+    .command('g', 'alias for generate')
+    .autocomplete(['app', 'hook', 'middleware', 'model', 'service', 'plugin'])
+    .action(function (args, callback) {
+      this.log('');
+      env.run('feathers:app', generatorOptions, callback);
+    });
+
+  vorpal
     .command('generate ', 'alias for generate app')
     .autocomplete(['app', 'hook', 'middleware', 'model', 'service', 'plugin'])
     .action(function (args, callback) {


### PR DESCRIPTION
I'm aware of #14, but I think it's still good to allow shortcut aliases. Is there a better way to allow shortcuts using vorpal?