### PR TITLE
service generator auto-mounting

### DIFF
--- a/src/commands/generate.js
+++ b/src/commands/generate.js
@@ -29,14 +29,16 @@ export default function(program) {
     .alias('g')
     .option('-f, --force', 'force file overwrites')
     .option('-p, --path <path>', 'output path (default is the current working directory)')
+    .option('-m, --mount <path>', 'path to feathers bootstrap json (default is false, which skips)')
     .action((template, name, command) => {
       const DEFAULTS = {
         template: 'app',
         path: '.',
+        mount: false,
         force: false
       };
 
-      let args = merge(DEFAULTS, { template, name, force: command.force, path: command.path });
+      let args = merge(DEFAULTS, { template, name, force: command.force, path: command.path, mount: command.mount });
       args.root = path.resolve(args.path);
       args.name = args.name || path.parse(args.root).name;
 


### PR DESCRIPTION
## overview

This aims to implement a dependency for the services generator as per the description in feathersjs/feathers-generator#4 and implemented in feathersjs/feathers-generator#10

This PR implements a `--mount` option which can be used to pass the location of the application's `feathers.json` file. This  allows the service generator will auto mount a generated service for [bootstrapping](https://github.com/feathersjs/feathers-bootstrap/blob/master/example/src/feathers.json) without locking the developer into a particular directory structure or filename.

I'm not 100% sure that this design is the best as I don't think it scales into the other generators (filters, models) as intuitively. I'm open to feedback on how else we could do this.

## tasks
- [x] add ability to pass a `--mount` parameter

