### PR TITLE
clean up jshint errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,8 @@
     "metalsmith": "^2.1.0",
     "ora": "^0.2.3",
     "request": "^2.72.0",
-    "root-check": "^1.0.0"
+    "root-check": "^1.0.0",
+    "vorpal": "^1.11.4"
   },
   "devDependencies": {
     "babel-cli": "^6.6.5",

--- a/src/commands/debug.js
+++ b/src/commands/debug.js
@@ -1,5 +1,5 @@
 /*
- * Interactive REPL with your app mounted 
+ * Interactive REPL with your app mounted
  * as an available variable.
  */
 
@@ -16,7 +16,7 @@
 
   vorpal
     .command('debug', 'Drop into an interactive REPL with your app as the context')
-    .action((args, callback) => {
+    .action((/*args, callback*/) => {
         // TODO (EK):
         // 1. Look at using Vantage https://github.com/dthree/vantage
 

--- a/src/commands/deploy.js
+++ b/src/commands/deploy.js
@@ -2,16 +2,18 @@
  * Deploy your Feathers server
  */
 
+/*
 const providers = [
   'heroku'
 ];
+*/
 
  export default function(vorpal) {
   const chalk = vorpal.chalk;
 
   vorpal
     .command('deploy', 'Deploy your Feathers app')
-    .action((args, callback) => {
+    .action((/*args, callback*/) => {
         // TODO (EK):
         // 1. Prompt for provider
         // 2. Generate copy appropriate template files (ie. Procfile, app.json)

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,5 @@
+/* jshint quotmark: false */
+
 import Debug from 'debug';
 import program from 'commander';
 import chalk from 'chalk';
@@ -22,7 +24,7 @@ export default function() {
   // If that fails show an error and exit out. We don't want to create files as root.
   rootCheck(`
     ${chalk.red("Easy with the 'sudo'.")}
-    
+
     Since feathers is a user command, there is no need to execute it with root permissions.
     If you're having permission errors when using feathers without sudo, please spend a few
     minutes learning more about how your system should work and make any necessary repairs.
@@ -35,7 +37,7 @@ export default function() {
   // TODO (EK): Add opt-in analytics reporting
   // using GA + insight. Look at how yeoman does it
   // https://github.com/yeoman/yo/blob/master/lib/cli.js#L172
-  
+
 
   // Register our commands with commander
   // debug(program);
@@ -72,14 +74,14 @@ export default function() {
     run();
   });
 
-  const run = () => {
+  function run() {
     program.parse(args);
-    
+
     // Show help if no other command was called
     if (!program.args.length) {
       program.help();
     }
-  };
+  }
 
   // Add some extra padding
   process.on('exit', function () {

--- a/src/utils/check-environment.js
+++ b/src/utils/check-environment.js
@@ -8,7 +8,7 @@ export function parseVersionNumber(versionString) {
   return versionString.toString().replace(/[^\d\.]/g, '');
 }
 
-export default function(args) {
+export default function(/*args*/) {
   const program = this;
   const minNodeVersion = parseVersionNumber(pkg.engines.node);
   const currentNodeVersion = parseVersionNumber(process.version);
@@ -20,13 +20,13 @@ export default function(args) {
     program.debug(`Running 'npm --version'...`);
     currentNpmVersion = parseVersionNumber(execSync('npm --version'));
   } catch (e) {
-    program.debug(chalk.red('Error running npm --version', error));
+    program.debug(chalk.red('Error running npm --version', e));
   }
 
   if (!currentNpmVersion) {
     console.log(chalk.red(`Unable to detect npm version. Do you have NPM installed?\n`));
   }
-  
+
   // Ensure minimum supported node version is used
   if (semver.gt(minNodeVersion, currentNodeVersion)) {
     console.log(chalk.yellow(`You should upgrade node to >=${minNodeVersion} to use feathers-cli`));
@@ -35,7 +35,7 @@ export default function(args) {
     // TODO (EK): Only enable if "verbose" mode
     console.log(`NodeJS version: v${currentNodeVersion} ${chalk.green('OK')}`);
   }
-  
+
   // Suggest NPM upgrade if minimum version not present
   if (semver.gt(minNpmVersion, currentNpmVersion)) {
     console.log(chalk.yellow(`You should upgrade npm to >=${minNpmVersion}. feathers-cli works best with recent versions of npm. Do this by running "npm install -g npm".`));

--- a/src/utils/check-for-updates.js
+++ b/src/utils/check-for-updates.js
@@ -3,7 +3,7 @@ import semver from 'semver';
 import chalk from 'chalk';
 import pkg from '../../package.json';
 
-const URL = 'https://registry.npmjs.org/feathers-cli'
+const URL = 'https://registry.npmjs.org/feathers-cli';
 
 export default function(args) {
   const program = this;

--- a/src/utils/start-server.js
+++ b/src/utils/start-server.js
@@ -1,14 +1,14 @@
 import pkg from '../../package.json';
 import { exec } from 'child_process';
 
-export default function(args) {
+export default function(/*args*/) {
   return new Promise((resolve, reject) => {
     console.log(`Starting Feathers app: ${pkg.name}`);
     console.log();
 
     // TODO (EK): Check to see if we are actually in an app directory
     // Maybe check for a feathers.json file.
-    
+
     // TODO (EK): Add support for args.port. Possibly just set as
     // an env var if present.
 

--- a/src/utils/update-cli.js
+++ b/src/utils/update-cli.js
@@ -1,11 +1,11 @@
 import { spawn } from 'child_process';
 
-export default function(args) {
+export default function(/*args*/) {
   const program = this;
 
   return new Promise((resolve, reject) => {
     program.debug(`Running 'npm install -g feathers-cli'...`);
-    
+
     const npm = spawn('npm', ['install', '-g', 'feathers-cli'], {stdio: 'inherit'});
 
     npm.on('close', function (code) {


### PR DESCRIPTION
## overview
 
This PR simply cleans up the jshint introduced in `2.0` as defined in #43 without removing placeholder code so that the test coverage will actually be what passes or fails the tests in travis. 

## tasks
 - [x] suppress or clean up all jshint errors

## test output

```
> feathers-cli@2.0.0-beta jshint /Users/kylec/repos/feathers-cli
> jshint src/. test/. --config


> feathers-cli@2.0.0-beta mocha /Users/kylec/repos/feathers-cli
> mocha test/ --compilers js:babel-core/register



  feathers-cli
    generator-feathers registration
      1) has registered the generator name
      2) registers all namespaces

  feathers-cli
    ✓ is CommonJS compatible (271ms)
    ✓ basic functionality


  2 passing (307ms)
  2 failing

  1) feathers-cli generator-feathers registration has registered the generator name:
     TypeError: Cannot read property 'getGeneratorNames' of undefined
      at Context.<anonymous> (test/commands/generate.test.js:13:25)

  2) feathers-cli generator-feathers registration registers all namespaces:
     TypeError: Cannot read property 'namespaces' of undefined
      at Context.<anonymous> (test/commands/generate.test.js:26:43)
```